### PR TITLE
Take screenshots of display on async start

### DIFF
--- a/pt_web_vnc/screenshot_monitor.py
+++ b/pt_web_vnc/screenshot_monitor.py
@@ -1,0 +1,43 @@
+import atexit
+from time import sleep
+from PIL import ImageGrab
+from threading import Thread
+
+from pt_web_vnc.utils import run_command
+
+
+class ScreenshotMonitor:
+    def __init__(self, display_id, screenshot_timeout) -> None:
+        self.display_id = display_id
+        self.screenshot_timeout = screenshot_timeout
+        self.image = None
+        self.thread = Thread(target=self.screenshot_loop, daemon=True)
+        self.thread.start()
+        atexit.register(self.stop)
+
+    def screenshot_loop(self):
+        while self.display_is_alive():
+            try:
+                self.image = self.take_screenshot()
+                sleep(self.screenshot_timeout)
+            except Exception as e:
+                print(f"Error taking screenshot: {e}")
+        self.stop()
+
+    def take_screenshot(self):
+        return ImageGrab.grab(xdisplay=f":{self.display_id}")
+
+    def display_is_alive(self) -> bool:
+        try:
+            run_command(
+                f"xwininfo -d ':{self.display_id}' -all -root",
+                timeout=3,
+                check=True,
+            )
+            return True
+        except Exception:
+            return False
+
+    def stop(self):
+        if self.thread and self.thread.is_alive():
+            self.thread.join()

--- a/pt_web_vnc/screenshot_monitor.py
+++ b/pt_web_vnc/screenshot_monitor.py
@@ -1,8 +1,9 @@
 import atexit
 import logging
-from time import sleep
-from PIL import ImageGrab
 from threading import Thread
+from time import sleep
+
+from PIL import ImageGrab
 
 from pt_web_vnc.utils import run_command
 
@@ -12,20 +13,21 @@ class ScreenshotMonitor:
         self.display_id = display_id
         self.screenshot_timeout = screenshot_timeout
         self.image = None
+        self.take_screenshots = True
         self.thread = Thread(target=self.screenshot_loop, daemon=True)
         self.thread.start()
         atexit.register(self.stop)
 
     def screenshot_loop(self):
-        while self.display_is_alive():
+        while self.display_is_alive() and self.take_screenshots:
             try:
-                self.image = self.take_screenshot()
+                self.image = self.grab_screenshot()
                 sleep(self.screenshot_timeout)
             except Exception as e:
                 logging.error(f"Error taking screenshot: {e}")
         self.stop()
 
-    def take_screenshot(self):
+    def grab_screenshot(self):
         return ImageGrab.grab(xdisplay=f":{self.display_id}")
 
     def display_is_alive(self) -> bool:
@@ -40,5 +42,6 @@ class ScreenshotMonitor:
             return False
 
     def stop(self):
+        self.take_screenshots = False
         if self.thread and self.thread.is_alive():
             self.thread.join()

--- a/pt_web_vnc/screenshot_monitor.py
+++ b/pt_web_vnc/screenshot_monitor.py
@@ -1,4 +1,5 @@
 import atexit
+import logging
 from time import sleep
 from PIL import ImageGrab
 from threading import Thread
@@ -21,7 +22,7 @@ class ScreenshotMonitor:
                 self.image = self.take_screenshot()
                 sleep(self.screenshot_timeout)
             except Exception as e:
-                print(f"Error taking screenshot: {e}")
+                logging.error(f"Error taking screenshot: {e}")
         self.stop()
 
     def take_screenshot(self):

--- a/pt_web_vnc/utils.py
+++ b/pt_web_vnc/utils.py
@@ -3,7 +3,7 @@ from shlex import split
 from subprocess import run
 
 
-def run_command(command_str: str, timeout: int) -> str:
+def run_command(command_str: str, timeout: int, check: bool = False) -> str:
     def __get_env():
         env = environ.copy()
         # Print output of commands in english
@@ -13,7 +13,7 @@ def run_command(command_str: str, timeout: int) -> str:
     try:
         resp = run(
             split(command_str),
-            check=False,
+            check=check,
             capture_output=True,
             timeout=timeout,
             env=__get_env(),

--- a/pt_web_vnc/vnc.py
+++ b/pt_web_vnc/vnc.py
@@ -4,6 +4,7 @@ from typing import Callable, Optional
 
 from .connection_details import VncConnectionDetails
 from .display_activity_monitor import start_activity_monitor, stop_activity_monitor
+from .screenshot_monitor import ScreenshotMonitor
 from .utils import run_command
 
 logger = logging.getLogger(__name__)
@@ -121,7 +122,8 @@ async def async_start(
     background_colour: Optional[str] = None,
     with_window_manager: Optional[bool] = None,
     on_display_activity: Optional[Callable] = None,
-) -> None:
+    screenshot_timeout: int = 0,
+) -> Optional[ScreenshotMonitor]:
     cmd = PtWebVncCommands.start(
         display_id=display_id,
         window_title=window_title,
@@ -147,6 +149,11 @@ async def async_start(
         start_activity_monitor(
             display_id, on_display_activity, connection_details(display_id)
         )
+
+    screenshot_monitor = None
+    if screenshot_timeout > 0:
+        screenshot_monitor = ScreenshotMonitor(display_id, screenshot_timeout)
+    return screenshot_monitor
 
 
 async def async_stop(display_id: int) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,8 @@ classifiers =
 
 [options]
 packages = find:
-# install_requires =
+install_requires =
+    Pillow >= 8.1.2
 
 
 include_package_data = True


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready| [Ticket](https://pi-top.atlassian.net/browse/FUR-2495) |


#### Main changes
`async_start` now returns a 'screenshot monitor' which continuously takes screenshots of the created virtual display and makes them available to user.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
