### PR TITLE
Redirect to DEVNULL instead of PIPE on async operations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Asynchronously start sharing display 0
   >>> import asyncio
   >>> from pt_web_vnc import async_start, async_connection_details, async_stop
   >>> # Start sharing display 0
-  >>> asyncio.run(async_start(display_id=0)
+  >>> asyncio.run(async_start(display_id=0))
   ...
   >>> # Get connection details
   >>> details = asyncio.run(async_connection_details(display_id=0))

--- a/pt_web_vnc/vnc.py
+++ b/pt_web_vnc/vnc.py
@@ -145,8 +145,8 @@ async def async_start(
     logging.info(f"Starting pt-web-vnc: {cmd}")
     proc = await asyncio.create_subprocess_shell(
         cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
     )
     await proc.wait()
     if callable(on_display_activity):
@@ -167,8 +167,8 @@ async def async_stop(display_id: int) -> None:
     await stop_screenshot_monitor(display_id)
     proc = await asyncio.create_subprocess_shell(
         cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
     )
     await proc.wait()
 


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
Using redirections to `PIPE` on async operations was causing the operation to get stuck; in particular on `async_start`, which produces a lot of output. Since the output of stdout/stderr are not used for `async_start` & `async_stop`, redirecting them to `DEVNULL` solves this issue for us.

There's a warning in the asyncio docs which might be related to this issue when using `wait()`. Read [here](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.wait).

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
